### PR TITLE
Always sort and dedup the matches list

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -184,17 +184,6 @@ func findLicensesInFile(cfg *viper.Viper, f string) error {
 	licenseArg := cfg.GetString(configurer.LicenseFlag)
 	if len(results.Matches) > 0 {
 
-		// Sort the matches by start and end index for each license ID
-		for _, match := range results.Matches {
-			sort.Slice(match, func(i, j int) bool {
-				if match[i].Begins != match[j].Begins {
-					return match[i].Begins < match[j].Begins
-				} else {
-					return match[i].Ends < match[j].Ends
-				}
-			})
-		}
-
 		// Print the matches by license ID in alphabetical order
 		fmt.Printf("\nFOUND LICENSE MATCHES:\n")
 		var found []string

--- a/identifier/identifier_test.go
+++ b/identifier/identifier_test.go
@@ -301,8 +301,8 @@ func Test_identifyLicensesInString(t *testing.T) {
 			want: IdentifierResults{
 				Matches: map[string][]Match{
 					"MIT": {
-						{Begins: 37, Ends: 597},
 						{Ends: 1058},
+						{Begins: 37, Ends: 597},
 						{Begins: 599, Ends: 1058},
 					},
 				},
@@ -534,6 +534,19 @@ func Test_identifyLicensesInStringPreChecks(t *testing.T) {
 		input      string
 		want       IdentifierResults
 	}{
+		{
+			name:       "duplicate matches",
+			configPath: "../testdata/duplicates/",
+			input:      "whatever noprechecktext whatever passes",
+			want: IdentifierResults{
+				Matches: map[string][]Match{"DuplicateMatchTest": {{Begins: 9, Ends: 22}}},
+				Blocks: []Block{
+					{Text: "whatever "},
+					{Text: "noprechecktext", Matches: []string{"DuplicateMatchTest"}},
+					{Text: " whatever passes"},
+				},
+			},
+		},
 		{
 			name:       "no prechecks matches template",
 			configPath: "../testdata/prechecks/no_prechecks/",

--- a/testdata/duplicates/config.json
+++ b/testdata/duplicates/config.json
@@ -1,0 +1,4 @@
+{
+  "resources": "resources"
+}
+

--- a/testdata/duplicates/resources/custom/default/license_patterns/DuplicateMatchTest/license_template.txt
+++ b/testdata/duplicates/resources/custom/default/license_patterns/DuplicateMatchTest/license_template.txt
@@ -1,0 +1,1 @@
+noprechecktext

--- a/testdata/duplicates/resources/custom/default/license_patterns/DuplicateMatchTest/license_template_duplicate.txt
+++ b/testdata/duplicates/resources/custom/default/license_patterns/DuplicateMatchTest/license_template_duplicate.txt
@@ -1,0 +1,1 @@
+noprechecktext


### PR DESCRIPTION
* This fixes an inconsistent test result (sort)
* Also removes redundant sort code to do sort in one place (and see results in more places)
* Added de-duplication because otherwise we just show a redundant match (one license same start/end repeated)

Fixes: #12