### PR TITLE
README with link to show --list output (resources/LIST.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ Since you may have multiple locations for resources and multiple SPDX and custom
 * Resource flags: **--spdx, --custom**
 * Config file location (used to locate resources): **--configPath, --configName**
 
+Example license library listing: [resources/LIST.md](resources/LIST.md)
+
 ## Runtime flags
 
 ### Resource flags

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,7 +108,7 @@ func y(isIt bool) string {
 }
 
 func listLicenses(cfg *viper.Viper) error {
-	lics, deprecatedLics, exceptions, deprecatedExceptions, err := licenses.List(cfg)
+	lics, deprecatedLics, exceptions, deprecatedExceptions, spdxVersion, err := licenses.List(cfg)
 	if err != nil {
 		return err
 	}
@@ -141,10 +141,15 @@ func listLicenses(cfg *viper.Viper) error {
 		fmt.Printf("| %v | %v | %v | %v |\n", e.ID, e.Name, e.Family, e.NumTemplates)
 	}
 
+	var licenseListVersion string
+	if spdxVersion != "" {
+		licenseListVersion = fmt.Sprintf("  (SPDX license list %v)", spdxVersion)
+	}
 	fmt.Println("## Runtime Configuration")
 	fmt.Printf("* resources: %v\n", cfg.GetString("resources"))
-	fmt.Printf("  * spdx/%v\n", cfg.GetString(configurer.SpdxFlag))
+	fmt.Printf("  * spdx/%v%v\n", cfg.GetString(configurer.SpdxFlag), licenseListVersion)
 	fmt.Printf("  * custom/%v\n", cfg.GetString(configurer.CustomFlag))
+	fmt.Printf("\n###### Generated on %v\n", time.Now().Format(time.RFC3339))
 	return nil
 }
 

--- a/resources/LIST.md
+++ b/resources/LIST.md
@@ -1,0 +1,515 @@
+## Licenses
+| ID | Name | Family | Templates | OSI Approved | FSF Libre |
+| :--- | :--- | :--- | ---: | :---: | :---: |
+| 0BSD | BSD Zero Clause License |  | 1 | Y |   |
+| AAL | Attribution Assurance License |  | 1 | Y |   |
+| ADSL | Amazon Digital Services License |  | 1 |   |   |
+| AFL-1.1 | Academic Free License v1.1 |  | 1 | Y | Y |
+| AFL-1.2 | Academic Free License v1.2 |  | 1 | Y | Y |
+| AFL-2.0 | Academic Free License v2.0 |  | 1 | Y | Y |
+| AFL-2.1 | Academic Free License v2.1 |  | 1 | Y | Y |
+| AFL-3.0 | Academic Free License v3.0 |  | 1 | Y | Y |
+| AGPL-1.0-only | Affero General Public License v1.0 only |  | 1 |   |   |
+| AGPL-1.0-or-later | Affero General Public License v1.0 or later |  | 1 |   |   |
+| AGPL-3.0-only | GNU Affero General Public License v3.0 only |  | 1 | Y | Y |
+| AGPL-3.0-or-later | GNU Affero General Public License v3.0 or later |  | 1 | Y | Y |
+| AMDPLPA | AMD's plpa_map.c License |  | 1 |   |   |
+| AML | Apple MIT License |  | 1 |   |   |
+| AMPAS | Academy of Motion Picture Arts and Sciences BSD |  | 1 |   |   |
+| ANTLR-PD | ANTLR Software Rights Notice |  | 1 |   |   |
+| ANTLR-PD-fallback | ANTLR Software Rights Notice with license fallback |  | 1 |   |   |
+| APAFML | Adobe Postscript AFM License |  | 1 |   |   |
+| APL-1.0 | Adaptive Public License 1.0 |  | 1 | Y |   |
+| APSL-1.0 | Apple Public Source License 1.0 |  | 1 | Y |   |
+| APSL-1.1 | Apple Public Source License 1.1 |  | 1 | Y |   |
+| APSL-1.2 | Apple Public Source License 1.2 |  | 1 | Y |   |
+| APSL-2.0 | Apple Public Source License 2.0 |  | 1 | Y | Y |
+| Abstyles | Abstyles License |  | 1 |   |   |
+| Adobe-2006 | Adobe Systems Incorporated Source Code License Agreement |  | 1 |   |   |
+| Adobe-Glyph | Adobe Glyph List License |  | 1 |   |   |
+| Aladdin | Aladdin Free Public License |  | 1 |   |   |
+| Apache-1.0 | Apache License 1.0 |  | 1 |   | Y |
+| Apache-1.1 | Apache License 1.1 |  | 1 | Y | Y |
+| Apache-2.0 | Apache License 2.0 | Apache | 4 | Y | Y |
+| App-s2p | App::s2p License |  | 1 |   |   |
+| Arphic-1999 | Arphic Public License |  | 1 |   |   |
+| Artistic-1.0 | Artistic License 1.0 |  | 1 | Y |   |
+| Artistic-1.0-Perl | Artistic License 1.0 (Perl) |  | 1 | Y |   |
+| Artistic-1.0-cl8 | Artistic License 1.0 w/clause 8 |  | 1 | Y |   |
+| Artistic-2.0 | Artistic License 2.0 |  | 1 | Y | Y |
+| BSD-1-Clause | BSD 1-Clause License |  | 1 | Y |   |
+| BSD-2-Clause | BSD 2-Clause "Simplified" License | BSD | 2 | Y | Y |
+| BSD-2-Clause-Patent | BSD-2-Clause Plus Patent License |  | 1 | Y |   |
+| BSD-2-Clause-Views | BSD 2-Clause with views sentence |  | 1 |   |   |
+| BSD-3-Clause | BSD 3-Clause "New" or "Revised" License | BSD | 3 | Y | Y |
+| BSD-3-Clause-Attribution | BSD with attribution |  | 1 |   |   |
+| BSD-3-Clause-Clear | BSD 3-Clause Clear License |  | 1 |   | Y |
+| BSD-3-Clause-LBNL | Lawrence Berkeley National Labs BSD variant license |  | 1 | Y |   |
+| BSD-3-Clause-Modification | BSD 3-Clause Modification |  | 1 |   |   |
+| BSD-3-Clause-No-Military-License | BSD 3-Clause No Military License |  | 1 |   |   |
+| BSD-3-Clause-No-Nuclear-License | BSD 3-Clause No Nuclear License |  | 1 |   |   |
+| BSD-3-Clause-No-Nuclear-License-2014 | BSD 3-Clause No Nuclear License 2014 |  | 1 |   |   |
+| BSD-3-Clause-No-Nuclear-Warranty | BSD 3-Clause No Nuclear Warranty |  | 1 |   |   |
+| BSD-3-Clause-Open-MPI | BSD 3-Clause Open MPI variant |  | 1 |   |   |
+| BSD-4-Clause | BSD 4-Clause "Original" or "Old" License |  | 1 |   | Y |
+| BSD-4-Clause-Shortened | BSD 4 Clause Shortened |  | 1 |   |   |
+| BSD-4-Clause-UC | BSD-4-Clause (University of California-Specific) |  | 1 |   |   |
+| BSD-Protection | BSD Protection License |  | 1 |   |   |
+| BSD-Source-Code | BSD Source Code Attribution |  | 1 |   |   |
+| BSL-1.0 | Boost Software License 1.0 |  | 1 | Y | Y |
+| BUSL-1.1 | Business Source License 1.1 |  | 1 |   |   |
+| Baekmuk | Baekmuk License |  | 1 |   |   |
+| Bahyph | Bahyph License |  | 1 |   |   |
+| Barr | Barr License |  | 1 |   |   |
+| Beerware | Beerware License |  | 1 |   |   |
+| BitTorrent-1.0 | BitTorrent Open Source License v1.0 |  | 1 |   |   |
+| BitTorrent-1.1 | BitTorrent Open Source License v1.1 |  | 1 |   | Y |
+| Bitstream-Vera | Bitstream Vera Font License |  | 1 |   |   |
+| Borceux | Borceux license |  | 1 |   |   |
+| C-UDA-1.0 | Computational Use of Data Agreement v1.0 |  | 1 |   |   |
+| CAL-1.0 | Cryptographic Autonomy License 1.0 |  | 1 | Y |   |
+| CAL-1.0-Combined-Work-Exception | Cryptographic Autonomy License 1.0 (Combined Work Exception) |  | 1 | Y |   |
+| CATOSL-1.1 | Computer Associates Trusted Open Source License 1.1 |  | 1 | Y |   |
+| CC-BY-1.0 | Creative Commons Attribution 1.0 Generic |  | 1 |   |   |
+| CC-BY-2.0 | Creative Commons Attribution 2.0 Generic |  | 1 |   |   |
+| CC-BY-2.5 | Creative Commons Attribution 2.5 Generic |  | 1 |   |   |
+| CC-BY-2.5-AU | Creative Commons Attribution 2.5 Australia |  | 1 |   |   |
+| CC-BY-3.0-AT | Creative Commons Attribution 3.0 Austria |  | 1 |   |   |
+| CC-BY-3.0-DE | Creative Commons Attribution 3.0 Germany |  | 1 |   |   |
+| CC-BY-3.0-IGO | Creative Commons Attribution 3.0 IGO |  | 1 |   |   |
+| CC-BY-3.0-NL | Creative Commons Attribution 3.0 Netherlands |  | 1 |   |   |
+| CC-BY-3.0-US | Creative Commons Attribution 3.0 United States |  | 1 |   |   |
+| CC-BY-4.0 | Creative Commons Attribution 4.0 International |  | 1 |   | Y |
+| CC-BY-NC-1.0 | Creative Commons Attribution Non Commercial 1.0 Generic |  | 1 |   |   |
+| CC-BY-NC-2.0 | Creative Commons Attribution Non Commercial 2.0 Generic |  | 1 |   |   |
+| CC-BY-NC-2.5 | Creative Commons Attribution Non Commercial 2.5 Generic |  | 1 |   |   |
+| CC-BY-NC-3.0 | Creative Commons Attribution Non Commercial 3.0 Unported |  | 1 |   |   |
+| CC-BY-NC-3.0-DE | Creative Commons Attribution Non Commercial 3.0 Germany |  | 1 |   |   |
+| CC-BY-NC-4.0 | Creative Commons Attribution Non Commercial 4.0 International |  | 1 |   |   |
+| CC-BY-NC-ND-1.0 | Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic |  | 1 |   |   |
+| CC-BY-NC-ND-2.0 | Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic |  | 1 |   |   |
+| CC-BY-NC-ND-2.5 | Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic |  | 1 |   |   |
+| CC-BY-NC-ND-3.0 | Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported |  | 1 |   |   |
+| CC-BY-NC-ND-3.0-DE | Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany |  | 1 |   |   |
+| CC-BY-NC-ND-3.0-IGO | Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO |  | 1 |   |   |
+| CC-BY-NC-ND-4.0 | Creative Commons Attribution Non Commercial No Derivatives 4.0 International |  | 1 |   |   |
+| CC-BY-NC-SA-1.0 | Creative Commons Attribution Non Commercial Share Alike 1.0 Generic |  | 1 |   |   |
+| CC-BY-NC-SA-2.0 | Creative Commons Attribution Non Commercial Share Alike 2.0 Generic |  | 1 |   |   |
+| CC-BY-NC-SA-2.0-UK | Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales |  | 1 |   |   |
+| CC-BY-NC-SA-2.5 | Creative Commons Attribution Non Commercial Share Alike 2.5 Generic |  | 1 |   |   |
+| CC-BY-NC-SA-3.0 | Creative Commons Attribution Non Commercial Share Alike 3.0 Unported |  | 1 |   |   |
+| CC-BY-NC-SA-3.0-DE | Creative Commons Attribution Non Commercial Share Alike 3.0 Germany |  | 1 |   |   |
+| CC-BY-NC-SA-3.0-IGO | Creative Commons Attribution Non Commercial Share Alike 3.0 IGO |  | 1 |   |   |
+| CC-BY-NC-SA-4.0 | Creative Commons Attribution Non Commercial Share Alike 4.0 International |  | 1 |   |   |
+| CC-BY-ND-1.0 | Creative Commons Attribution No Derivatives 1.0 Generic |  | 1 |   |   |
+| CC-BY-ND-2.0 | Creative Commons Attribution No Derivatives 2.0 Generic |  | 1 |   |   |
+| CC-BY-ND-2.5 | Creative Commons Attribution No Derivatives 2.5 Generic |  | 1 |   |   |
+| CC-BY-ND-3.0 | Creative Commons Attribution No Derivatives 3.0 Unported |  | 1 |   |   |
+| CC-BY-ND-3.0-DE | Creative Commons Attribution No Derivatives 3.0 Germany |  | 1 |   |   |
+| CC-BY-ND-4.0 | Creative Commons Attribution No Derivatives 4.0 International |  | 1 |   |   |
+| CC-BY-SA-1.0 | Creative Commons Attribution Share Alike 1.0 Generic |  | 1 |   |   |
+| CC-BY-SA-2.0 | Creative Commons Attribution Share Alike 2.0 Generic |  | 1 |   |   |
+| CC-BY-SA-2.0-UK | Creative Commons Attribution Share Alike 2.0 England and Wales |  | 1 |   |   |
+| CC-BY-SA-2.1-JP | Creative Commons Attribution Share Alike 2.1 Japan |  | 1 |   |   |
+| CC-BY-SA-2.5 | Creative Commons Attribution Share Alike 2.5 Generic |  | 1 |   |   |
+| CC-BY-SA-3.0-AT | Creative Commons Attribution Share Alike 3.0 Austria |  | 1 |   |   |
+| CC-BY-SA-3.0-DE | Creative Commons Attribution Share Alike 3.0 Germany |  | 1 |   |   |
+| CC-BY-SA-4.0 | Creative Commons Attribution Share Alike 4.0 International |  | 1 |   | Y |
+| CC-PDDC | Creative Commons Public Domain Dedication and Certification |  | 1 |   |   |
+| CC0-1.0 | Creative Commons Zero v1.0 Universal |  | 1 |   | Y |
+| CDDL-1.0 | Common Development and Distribution License 1.0 |  | 1 | Y | Y |
+| CDDL-1.1 | Common Development and Distribution License 1.1 |  | 1 |   |   |
+| CDL-1.0 | Common Documentation License 1.0 |  | 1 |   |   |
+| CDLA-Permissive-1.0 | Community Data License Agreement Permissive 1.0 |  | 1 |   |   |
+| CDLA-Permissive-2.0 | Community Data License Agreement Permissive 2.0 |  | 1 |   |   |
+| CDLA-Sharing-1.0 | Community Data License Agreement Sharing 1.0 |  | 1 |   |   |
+| CECILL-1.0 | CeCILL Free Software License Agreement v1.0 |  | 1 |   |   |
+| CECILL-1.1 | CeCILL Free Software License Agreement v1.1 |  | 1 |   |   |
+| CERN-OHL-1.1 | CERN Open Hardware Licence v1.1 |  | 1 |   |   |
+| CERN-OHL-1.2 | CERN Open Hardware Licence v1.2 |  | 1 |   |   |
+| CERN-OHL-P-2.0 | CERN Open Hardware Licence Version 2 - Permissive |  | 1 | Y |   |
+| CERN-OHL-S-2.0 | CERN Open Hardware Licence Version 2 - Strongly Reciprocal |  | 1 | Y |   |
+| CERN-OHL-W-2.0 | CERN Open Hardware Licence Version 2 - Weakly Reciprocal |  | 1 | Y |   |
+| CNRI-Jython | CNRI Jython License |  | 1 |   |   |
+| CNRI-Python | CNRI Python License |  | 1 | Y |   |
+| CNRI-Python-GPL-Compatible | CNRI Python Open Source GPL Compatible License Agreement |  | 1 |   |   |
+| CPAL-1.0 | Common Public Attribution License 1.0 |  | 1 | Y | Y |
+| CPL-1.0 | Common Public License 1.0 |  | 1 | Y | Y |
+| CPOL-1.02 | Code Project Open License 1.02 |  | 1 |   |   |
+| CUA-OPL-1.0 | CUA Office Public License v1.0 |  | 1 | Y |   |
+| Caldera | Caldera License |  | 1 |   |   |
+| ClArtistic | Clarified Artistic License |  | 1 |   | Y |
+| Condor-1.1 | Condor Public License v1.1 |  | 1 |   | Y |
+| Crossword | Crossword License |  | 1 |   |   |
+| CrystalStacker | CrystalStacker License |  | 1 |   |   |
+| Cube | Cube License |  | 1 |   |   |
+| DL-DE-BY-2.0 | Data licence Germany – attribution – version 2.0 |  | 1 |   |   |
+| DOC | DOC License |  | 1 |   |   |
+| DRL-1.0 | Detection Rule License 1.0 |  | 1 |   |   |
+| DSDP | DSDP License |  | 1 |   |   |
+| Dotseqn | Dotseqn License |  | 1 |   |   |
+| ECL-1.0 | Educational Community License v1.0 |  | 1 | Y |   |
+| ECL-2.0 | Educational Community License v2.0 |  | 1 | Y | Y |
+| EFL-1.0 | Eiffel Forum License v1.0 |  | 1 | Y |   |
+| EFL-2.0 | Eiffel Forum License v2.0 |  | 1 | Y | Y |
+| EPICS | EPICS Open License |  | 1 |   |   |
+| EPL-2.0 | Eclipse Public License 2.0 |  | 1 | Y | Y |
+| EUPL-1.0 | European Union Public License 1.0 |  | 1 |   |   |
+| EUPL-1.1 | European Union Public License 1.1 |  | 1 | Y | Y |
+| Elastic-2.0 | Elastic License 2.0 |  | 1 |   |   |
+| Entessa | Entessa Public License v1.0 |  | 1 | Y |   |
+| Eurosym | Eurosym License |  | 1 |   |   |
+| FDK-AAC | Fraunhofer FDK AAC Codec Library |  | 1 |   |   |
+| FSFAP | FSF All Permissive License |  | 1 |   | Y |
+| FSFUL | FSF Unlimited License |  | 1 |   |   |
+| FSFULLR | FSF Unlimited License (with License Retention) |  | 1 |   |   |
+| FTL | Freetype Project License |  | 1 |   | Y |
+| Fair | Fair License |  | 1 | Y |   |
+| Frameworx-1.0 | Frameworx Open License 1.0 |  | 1 | Y |   |
+| FreeBSD-DOC | FreeBSD Documentation License |  | 1 |   |   |
+| GD | GD License |  | 1 |   |   |
+| GFDL-1.1-invariants-only | GNU Free Documentation License v1.1 only - invariants |  | 1 |   |   |
+| GFDL-1.1-invariants-or-later | GNU Free Documentation License v1.1 or later - invariants |  | 1 |   |   |
+| GFDL-1.1-no-invariants-only | GNU Free Documentation License v1.1 only - no invariants |  | 1 |   |   |
+| GFDL-1.1-no-invariants-or-later | GNU Free Documentation License v1.1 or later - no invariants |  | 1 |   |   |
+| GFDL-1.1-only | GNU Free Documentation License v1.1 only |  | 1 |   | Y |
+| GFDL-1.1-or-later | GNU Free Documentation License v1.1 or later |  | 1 |   | Y |
+| GFDL-1.2-invariants-only | GNU Free Documentation License v1.2 only - invariants |  | 1 |   |   |
+| GFDL-1.2-invariants-or-later | GNU Free Documentation License v1.2 or later - invariants |  | 1 |   |   |
+| GFDL-1.2-no-invariants-only | GNU Free Documentation License v1.2 only - no invariants |  | 1 |   |   |
+| GFDL-1.2-no-invariants-or-later | GNU Free Documentation License v1.2 or later - no invariants |  | 1 |   |   |
+| GFDL-1.2-only | GNU Free Documentation License v1.2 only |  | 1 |   | Y |
+| GFDL-1.2-or-later | GNU Free Documentation License v1.2 or later |  | 1 |   | Y |
+| GFDL-1.3-invariants-only | GNU Free Documentation License v1.3 only - invariants |  | 1 |   |   |
+| GFDL-1.3-invariants-or-later | GNU Free Documentation License v1.3 or later - invariants |  | 1 |   |   |
+| GFDL-1.3-no-invariants-only | GNU Free Documentation License v1.3 only - no invariants |  | 1 |   |   |
+| GFDL-1.3-no-invariants-or-later | GNU Free Documentation License v1.3 or later - no invariants |  | 1 |   |   |
+| GFDL-1.3-only | GNU Free Documentation License v1.3 only |  | 1 |   | Y |
+| GFDL-1.3-or-later | GNU Free Documentation License v1.3 or later |  | 1 |   | Y |
+| GL2PS | GL2PS License |  | 1 |   |   |
+| GLWTPL | Good Luck With That Public License |  | 1 |   |   |
+| GPL-1.0-only | GNU General Public License v1.0 only |  | 1 |   |   |
+| GPL-1.0-or-later | GNU General Public License v1.0 or later |  | 1 |   |   |
+| GPL-2.0-only | GNU General Public License v2.0 only |  | 1 | Y | Y |
+| GPL-2.0-or-later | GNU General Public License v2.0 or later |  | 1 | Y | Y |
+| GPL-3.0-only | GNU General Public License v3.0 only |  | 1 | Y | Y |
+| GPL-3.0-or-later | GNU General Public License v3.0 or later |  | 1 | Y | Y |
+| Giftware | Giftware License |  | 1 |   |   |
+| Glide | 3dfx Glide License |  | 1 |   |   |
+| Glulxe | Glulxe License |  | 1 |   |   |
+| HPND | Historical Permission Notice and Disclaimer |  | 1 | Y | Y |
+| HPND-sell-variant | Historical Permission Notice and Disclaimer - sell variant |  | 1 |   |   |
+| HTMLTIDY | HTML Tidy License |  | 1 |   |   |
+| HaskellReport | Haskell Language Report License |  | 1 |   |   |
+| Hippocratic-2.1 | Hippocratic License 2.1 |  | 1 |   |   |
+| ICU | ICU License |  | 1 |   |   |
+| IJG | Independent JPEG Group License |  | 1 |   | Y |
+| IPA | IPA Font License |  | 1 | Y | Y |
+| IPL-1.0 | IBM Public License v1.0 |  | 1 | Y | Y |
+| ISC | ISC License | ISC | 2 | Y | Y |
+| ImageMagick | ImageMagick License |  | 1 |   |   |
+| Imlib2 | Imlib2 License |  | 1 |   | Y |
+| Info-ZIP | Info-ZIP License |  | 1 |   |   |
+| Intel | Intel Open Source License |  | 1 | Y | Y |
+| Intel-ACPI | Intel ACPI Software License Agreement |  | 1 |   |   |
+| Interbase-1.0 | Interbase Public License v1.0 |  | 1 |   |   |
+| JPNIC | Japan Network Information Center License |  | 1 |   |   |
+| JSON | JSON License |  | 1 |   |   |
+| Jam | Jam License |  | 1 | Y |   |
+| JasPer-2.0 | JasPer License |  | 1 |   |   |
+| LGPL-2.0-only | GNU Library General Public License v2 only |  | 1 | Y |   |
+| LGPL-2.0-or-later | GNU Library General Public License v2 or later |  | 1 | Y |   |
+| LGPL-2.1-only | GNU Lesser General Public License v2.1 only |  | 1 | Y | Y |
+| LGPL-2.1-or-later | GNU Lesser General Public License v2.1 or later |  | 1 | Y | Y |
+| LGPL-3.0-only | GNU Lesser General Public License v3.0 only |  | 1 | Y | Y |
+| LGPL-3.0-or-later | GNU Lesser General Public License v3.0 or later |  | 1 | Y | Y |
+| LGPLLR | Lesser General Public License For Linguistic Resources |  | 1 |   |   |
+| LPL-1.02 | Lucent Public License v1.02 |  | 1 | Y | Y |
+| LPPL-1.0 | LaTeX Project Public License v1.0 |  | 1 |   |   |
+| LPPL-1.1 | LaTeX Project Public License v1.1 |  | 1 |   |   |
+| LPPL-1.2 | LaTeX Project Public License v1.2 |  | 1 |   | Y |
+| LPPL-1.3a | LaTeX Project Public License v1.3a |  | 1 |   | Y |
+| LPPL-1.3c | LaTeX Project Public License v1.3c |  | 1 | Y |   |
+| Latex2e | Latex2e License |  | 1 |   |   |
+| Leptonica | Leptonica License |  | 1 |   |   |
+| LiLiQ-P-1.1 | Licence Libre du Québec – Permissive version 1.1 |  | 1 | Y |   |
+| LiLiQ-R-1.1 | Licence Libre du Québec – Réciprocité version 1.1 |  | 1 | Y |   |
+| Libpng | libpng License |  | 1 |   |   |
+| Linux-OpenIB | Linux Kernel Variant of OpenIB.org license |  | 1 |   |   |
+| Linux-man-pages-copyleft | Linux man-pages Copyleft |  | 1 |   |   |
+| MIT | MIT License | MIT | 2 | Y | Y |
+| MIT-0 | MIT No Attribution |  | 1 | Y |   |
+| MIT-CMU | CMU License |  | 1 |   |   |
+| MIT-Modern-Variant | MIT License Modern Variant |  | 1 | Y |   |
+| MIT-advertising | Enlightenment License (e16) |  | 1 |   |   |
+| MIT-enna | enna License |  | 1 |   |   |
+| MIT-feh | feh License |  | 1 |   |   |
+| MIT-open-group | MIT Open Group variant |  | 1 |   |   |
+| MITNFA | MIT +no-false-attribs license |  | 1 |   |   |
+| MPL-1.0 | Mozilla Public License 1.0 |  | 1 | Y |   |
+| MPL-1.1 | Mozilla Public License 1.1 |  | 1 | Y | Y |
+| MPL-2.0 | Mozilla Public License 2.0 |  | 1 | Y | Y |
+| MPL-2.0-no-copyleft-exception | Mozilla Public License 2.0 (no copyleft exception) |  | 1 | Y |   |
+| MS-LPL | Microsoft Limited Public License |  | 1 |   |   |
+| MS-PL | Microsoft Public License |  | 1 | Y | Y |
+| MS-RL | Microsoft Reciprocal License |  | 1 | Y | Y |
+| MTLL | Matrix Template Library License |  | 1 |   |   |
+| MakeIndex | MakeIndex License |  | 1 |   |   |
+| Minpack | Minpack License |  | 1 |   |   |
+| MirOS | The MirOS Licence |  | 1 | Y |   |
+| Motosoto | Motosoto License |  | 1 | Y |   |
+| MulanPSL-2.0 | Mulan Permissive Software License, Version 2 |  | 1 | Y |   |
+| Mup | Mup License |  | 1 |   |   |
+| NAIST-2003 | Nara Institute of Science and Technology License (2003) |  | 1 |   |   |
+| NASA-1.3 | NASA Open Source Agreement 1.3 |  | 1 | Y |   |
+| NBPL-1.0 | Net Boolean Public License v1 |  | 1 |   |   |
+| NCSA | University of Illinois/NCSA Open Source License |  | 1 | Y | Y |
+| NGPL | Nethack General Public License |  | 1 | Y |   |
+| NICTA-1.0 | NICTA Public Software License, Version 1.0 |  | 1 |   |   |
+| NIST-PD | NIST Public Domain Notice |  | 1 |   |   |
+| NIST-PD-fallback | NIST Public Domain Notice with license fallback |  | 1 |   |   |
+| NLOD-1.0 | Norwegian Licence for Open Government Data (NLOD) 1.0 |  | 1 |   |   |
+| NLOD-2.0 | Norwegian Licence for Open Government Data (NLOD) 2.0 |  | 1 |   |   |
+| NLPL | No Limit Public License |  | 1 |   |   |
+| NOSL | Netizen Open Source License |  | 1 |   | Y |
+| NPL-1.0 | Netscape Public License v1.0 |  | 1 |   | Y |
+| NPOSL-3.0 | Non-Profit Open Software License 3.0 |  | 1 | Y |   |
+| NRL | NRL License |  | 1 |   |   |
+| NTP | NTP License |  | 1 | Y |   |
+| NTP-0 | NTP No Attribution |  | 1 |   |   |
+| Naumen | Naumen Public License |  | 1 | Y |   |
+| Net-SNMP | Net-SNMP License |  | 1 |   |   |
+| NetCDF | NetCDF license |  | 1 |   |   |
+| Newsletr | Newsletr License |  | 1 |   |   |
+| Nokia | Nokia Open Source License |  | 1 | Y | Y |
+| Noweb | Noweb License |  | 1 |   |   |
+| O-UDA-1.0 | Open Use of Data Agreement v1.0 |  | 1 |   |   |
+| OCCT-PL | Open CASCADE Technology Public License |  | 1 |   |   |
+| OCLC-2.0 | OCLC Research Public License 2.0 |  | 1 | Y |   |
+| ODC-By-1.0 | Open Data Commons Attribution License v1.0 |  | 1 |   |   |
+| ODbL-1.0 | Open Data Commons Open Database License v1.0 |  | 1 |   | Y |
+| OFL-1.0 | SIL Open Font License 1.0 |  | 1 |   | Y |
+| OFL-1.0-RFN | SIL Open Font License 1.0 with Reserved Font Name |  | 1 |   |   |
+| OFL-1.0-no-RFN | SIL Open Font License 1.0 with no Reserved Font Name |  | 1 |   |   |
+| OFL-1.1 | SIL Open Font License 1.1 |  | 1 | Y | Y |
+| OFL-1.1-RFN | SIL Open Font License 1.1 with Reserved Font Name |  | 1 | Y |   |
+| OFL-1.1-no-RFN | SIL Open Font License 1.1 with no Reserved Font Name |  | 1 | Y |   |
+| OGC-1.0 | OGC Software License, Version 1.0 |  | 1 |   |   |
+| OGDL-Taiwan-1.0 | Taiwan Open Government Data License, version 1.0 |  | 1 |   |   |
+| OGL-Canada-2.0 | Open Government Licence - Canada |  | 1 |   |   |
+| OGL-UK-2.0 | Open Government Licence v2.0 |  | 1 |   |   |
+| OGL-UK-3.0 | Open Government Licence v3.0 |  | 1 |   |   |
+| OGTSL | Open Group Test Suite License |  | 1 | Y |   |
+| OLDAP-1.1 | Open LDAP Public License v1.1 |  | 1 |   |   |
+| OLDAP-1.2 | Open LDAP Public License v1.2 |  | 1 |   |   |
+| OLDAP-1.3 | Open LDAP Public License v1.3 |  | 1 |   |   |
+| OLDAP-1.4 | Open LDAP Public License v1.4 |  | 1 |   |   |
+| OLDAP-2.0 | Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B) |  | 1 |   |   |
+| OLDAP-2.0.1 | Open LDAP Public License v2.0.1 |  | 1 |   |   |
+| OLDAP-2.1 | Open LDAP Public License v2.1 |  | 1 |   |   |
+| OLDAP-2.2 | Open LDAP Public License v2.2 |  | 1 |   |   |
+| OLDAP-2.2.1 | Open LDAP Public License v2.2.1 |  | 1 |   |   |
+| OLDAP-2.2.2 | Open LDAP Public License 2.2.2 |  | 1 |   |   |
+| OLDAP-2.3 | Open LDAP Public License v2.3 |  | 1 |   | Y |
+| OLDAP-2.4 | Open LDAP Public License v2.4 |  | 1 |   |   |
+| OLDAP-2.5 | Open LDAP Public License v2.5 |  | 1 |   |   |
+| OLDAP-2.6 | Open LDAP Public License v2.6 |  | 1 |   |   |
+| OLDAP-2.7 | Open LDAP Public License v2.7 |  | 1 |   | Y |
+| OLDAP-2.8 | Open LDAP Public License v2.8 |  | 1 | Y |   |
+| OML | Open Market License |  | 1 |   |   |
+| OPL-1.0 | Open Public License v1.0 |  | 1 |   |   |
+| OPUBL-1.0 | Open Publication License v1.0 |  | 1 |   |   |
+| OSL-1.0 | Open Software License 1.0 |  | 1 | Y | Y |
+| OSL-1.1 | Open Software License 1.1 |  | 1 |   | Y |
+| OSL-2.0 | Open Software License 2.0 |  | 1 | Y | Y |
+| OSL-2.1 | Open Software License 2.1 |  | 1 | Y | Y |
+| OSL-3.0 | Open Software License 3.0 |  | 1 | Y | Y |
+| OpenSSL | OpenSSL License |  | 1 |   | Y |
+| PDDL-1.0 | Open Data Commons Public Domain Dedication & License 1.0 |  | 1 |   |   |
+| PHP-3.0 | PHP License v3.0 |  | 1 | Y |   |
+| PHP-3.01 | PHP License v3.01 |  | 1 | Y | Y |
+| PSF-2.0 | Python Software Foundation License 2.0 |  | 1 |   |   |
+| Parity-6.0.0 | The Parity Public License 6.0.0 |  | 1 |   |   |
+| Plexus | Plexus Classworlds License |  | 1 |   |   |
+| PostgreSQL | PostgreSQL License |  | 1 | Y |   |
+| Python-2.0 | Python License 2.0 |  | 1 | Y | Y |
+| Python-2.0.1 | Python License 2.0.1 |  | 1 |   |   |
+| QPL-1.0 | Q Public License 1.0 |  | 1 | Y | Y |
+| Qhull | Qhull License |  | 1 |   |   |
+| RHeCos-1.1 | Red Hat eCos Public License v1.1 |  | 1 |   |   |
+| RPL-1.1 | Reciprocal Public License 1.1 |  | 1 | Y |   |
+| RPL-1.5 | Reciprocal Public License 1.5 |  | 1 | Y |   |
+| RPSL-1.0 | RealNetworks Public Source License v1.0 |  | 1 | Y | Y |
+| RSA-MD | RSA Message-Digest License |  | 1 |   |   |
+| RSCPL | Ricoh Source Code Public License |  | 1 | Y |   |
+| Rdisc | Rdisc License |  | 1 |   |   |
+| Ruby | Ruby License |  | 1 |   | Y |
+| SAX-PD | Sax Public Domain Notice |  | 1 |   |   |
+| SCEA | SCEA Shared Source License |  | 1 |   |   |
+| SGI-B-1.0 | SGI Free Software License B v1.0 |  | 1 |   |   |
+| SGI-B-1.1 | SGI Free Software License B v1.1 |  | 1 |   |   |
+| SGI-B-2.0 | SGI Free Software License B v2.0 |  | 1 |   | Y |
+| SHL-0.5 | Solderpad Hardware License v0.5 |  | 1 |   |   |
+| SHL-0.51 | Solderpad Hardware License, Version 0.51 |  | 1 |   |   |
+| SISSL | Sun Industry Standards Source License v1.1 |  | 1 | Y | Y |
+| SISSL-1.2 | Sun Industry Standards Source License v1.2 |  | 1 |   |   |
+| SMLNJ | Standard ML of New Jersey License |  | 1 |   | Y |
+| SMPPL | Secure Messaging Protocol Public License |  | 1 |   |   |
+| SNIA | SNIA Public License 1.1 |  | 1 |   |   |
+| SPL-1.0 | Sun Public License v1.0 |  | 1 | Y | Y |
+| SSH-OpenSSH | SSH OpenSSH license |  | 1 |   |   |
+| SSH-short | SSH short notice |  | 1 |   |   |
+| SWL | Scheme Widget Library (SWL) Software License Agreement |  | 1 |   |   |
+| Saxpath | Saxpath License |  | 1 |   |   |
+| SchemeReport | Scheme Language Report License |  | 1 |   |   |
+| Sendmail | Sendmail License |  | 1 |   |   |
+| Sendmail-8.23 | Sendmail License 8.23 |  | 1 |   |   |
+| SimPL-2.0 | Simple Public License 2.0 |  | 1 | Y |   |
+| Sleepycat | Sleepycat License |  | 1 | Y | Y |
+| Spencer-86 | Spencer License 86 |  | 1 |   |   |
+| Spencer-94 | Spencer License 94 |  | 1 |   |   |
+| Spencer-99 | Spencer License 99 |  | 1 |   |   |
+| SugarCRM-1.1.3 | SugarCRM Public License v1.1.3 |  | 1 |   |   |
+| TAPR-OHL-1.0 | TAPR Open Hardware License v1.0 |  | 1 |   |   |
+| TCL | TCL/TK License |  | 1 |   |   |
+| TCP-wrappers | TCP Wrappers License |  | 1 |   |   |
+| TMate | TMate Open Source License |  | 1 |   |   |
+| TORQUE-1.1 | TORQUE v2.5+ Software License v1.1 |  | 1 |   |   |
+| TOSL | Trusster Open Source License |  | 1 |   |   |
+| TU-Berlin-1.0 | Technische Universitaet Berlin License 1.0 |  | 1 |   |   |
+| TU-Berlin-2.0 | Technische Universitaet Berlin License 2.0 |  | 1 |   |   |
+| UCL-1.0 | Upstream Compatibility License v1.0 |  | 1 | Y |   |
+| UPL-1.0 | Universal Permissive License v1.0 |  | 1 | Y | Y |
+| Unicode-DFS-2015 | Unicode License Agreement - Data Files and Software (2015) |  | 1 |   |   |
+| Unicode-DFS-2016 | Unicode License Agreement - Data Files and Software (2016) |  | 1 | Y |   |
+| Unicode-TOU | Unicode Terms of Use |  | 1 |   |   |
+| Unlicense | The Unlicense |  | 1 | Y | Y |
+| VOSTROM | VOSTROM Public License for Open Source |  | 1 |   |   |
+| VSL-1.0 | Vovida Software License v1.0 |  | 1 | Y |   |
+| Vim | Vim License |  | 1 |   | Y |
+| W3C | W3C Software Notice and License (2002-12-31) |  | 1 | Y | Y |
+| W3C-20150513 | W3C Software Notice and Document License (2015-05-13) |  | 1 |   |   |
+| WTFPL | Do What The F*ck You Want To Public License |  | 1 |   | Y |
+| Watcom-1.0 | Sybase Open Watcom Public License 1.0 |  | 1 | Y |   |
+| Wsuipa | Wsuipa License |  | 1 |   |   |
+| X11 | X11 License |  | 1 |   | Y |
+| X11-distribute-modifications-variant | X11 License Distribution Modification Variant |  | 1 |   |   |
+| XFree86-1.1 | XFree86 License 1.1 |  | 1 |   | Y |
+| XSkat | XSkat License |  | 1 |   |   |
+| Xerox | Xerox License |  | 1 |   |   |
+| Xnet | X.Net License |  | 1 | Y |   |
+| YPL-1.0 | Yahoo! Public License v1.0 |  | 1 |   |   |
+| YPL-1.1 | Yahoo! Public License v1.1 |  | 1 |   | Y |
+| ZPL-1.1 | Zope Public License 1.1 |  | 1 |   |   |
+| ZPL-2.0 | Zope Public License 2.0 |  | 1 | Y | Y |
+| ZPL-2.1 | Zope Public License 2.1 |  | 1 | Y | Y |
+| Zed | Zed License |  | 1 |   |   |
+| Zend-2.0 | Zend License v2.0 |  | 1 |   | Y |
+| Zimbra-1.3 | Zimbra Public License v1.3 |  | 1 |   | Y |
+| Zimbra-1.4 | Zimbra Public License v1.4 |  | 1 |   |   |
+| Zlib | zlib License |  | 1 | Y | Y |
+| blessing | SQLite Blessing |  | 1 |   |   |
+| bzip2-1.0.6 | bzip2 and libbzip2 License v1.0.6 |  | 1 |   |   |
+| curl | curl License |  | 1 |   |   |
+| diffmark | diffmark license |  | 1 |   |   |
+| dvipdfm | dvipdfm License |  | 1 |   |   |
+| eGenix | eGenix.com Public License 1.1.0 |  | 1 |   |   |
+| etalab-2.0 | Etalab Open License 2.0 |  | 1 |   |   |
+| gSOAP-1.3b | gSOAP Public License v1.3b |  | 1 |   |   |
+| gnuplot | gnuplot License |  | 1 |   | Y |
+| libpng-2.0 | PNG Reference Library version 2 |  | 1 |   |   |
+| libselinux-1.0 | libselinux public domain notice |  | 1 |   |   |
+| libtiff | libtiff License |  | 1 |   |   |
+| mpi-permissive | mpi Permissive License |  | 1 |   |   |
+| mpich2 | mpich2 License |  | 1 |   |   |
+| mplus | mplus Font License |  | 1 |   |   |
+| psfrag | psfrag License |  | 1 |   |   |
+| psutils | psutils License |  | 1 |   |   |
+| xinetd | xinetd License |  | 1 |   | Y |
+| xpp | XPP License |  | 1 |   |   |
+| zlib-acknowledgement | zlib/libpng License with Acknowledgement |  | 1 |   |   |
+## Exceptions
+| ID | Name | Family | Templates |
+| :--- | :--- | :--- | ---: |
+| 389-exception | 389 Directory Server Exception |  | 1 |
+| Autoconf-exception-2.0 | Autoconf exception 2.0 |  | 1 |
+| Autoconf-exception-3.0 | Autoconf exception 3.0 |  | 1 |
+| Bison-exception-2.2 | Bison exception 2.2 |  | 1 |
+| Bootloader-exception | Bootloader Distribution Exception |  | 1 |
+| CLISP-exception-2.0 | CLISP exception 2.0 |  | 1 |
+| Classpath-exception-2.0 | Classpath exception 2.0 |  | 1 |
+| DigiRule-FOSS-exception | DigiRule FOSS License Exception |  | 1 |
+| FLTK-exception | FLTK exception |  | 1 |
+| Fawkes-Runtime-exception | Fawkes Runtime Exception |  | 1 |
+| Font-exception-2.0 | Font exception 2.0 |  | 1 |
+| GCC-exception-2.0 | GCC Runtime Library exception 2.0 |  | 1 |
+| GCC-exception-3.1 | GCC Runtime Library exception 3.1 |  | 1 |
+| GPL-3.0-linking-exception | GPL-3.0 Linking Exception |  | 1 |
+| GPL-3.0-linking-source-exception | GPL-3.0 Linking Exception (with Corresponding Source) |  | 1 |
+| GPL-CC-1.0 | GPL Cooperation Commitment 1.0 |  | 1 |
+| GStreamer-exception-2005 | GStreamer Exception (2005) |  | 1 |
+| GStreamer-exception-2008 | GStreamer Exception (2008) |  | 1 |
+| KiCad-libraries-exception | KiCad Libraries Exception |  | 1 |
+| LGPL-3.0-linking-exception | LGPL-3.0 Linking Exception |  | 1 |
+| LLVM-exception | LLVM Exception |  | 1 |
+| LZMA-exception | LZMA exception |  | 1 |
+| Libtool-exception | Libtool Exception |  | 1 |
+| Linux-syscall-note | Linux Syscall Note |  | 1 |
+| OCCT-exception-1.0 | Open CASCADE Exception 1.0 |  | 1 |
+| OCaml-LGPL-linking-exception | OCaml LGPL Linking Exception |  | 1 |
+| OpenJDK-assembly-exception-1.0 | OpenJDK Assembly exception 1.0 |  | 1 |
+| PS-or-PDF-font-exception-20170817 | PS/PDF font exception (2017-08-17) |  | 1 |
+| Qt-GPL-exception-1.0 | Qt GPL exception 1.0 |  | 1 |
+| Qt-LGPL-exception-1.1 | Qt LGPL exception 1.1 |  | 1 |
+| Qwt-exception-1.0 | Qwt exception 1.0 |  | 1 |
+| Swift-exception | Swift Exception |  | 1 |
+| Universal-FOSS-exception-1.0 | Universal FOSS Exception, Version 1.0 |  | 1 |
+| WxWindows-exception-3.1 | WxWindows Library Exception 3.1 |  | 1 |
+| eCos-exception-2.0 | eCos exception 2.0 |  | 1 |
+| freertos-exception-2.0 | FreeRTOS Exception 2.0 |  | 1 |
+| gnu-javamail-exception | GNU JavaMail exception |  | 1 |
+| i2p-gpl-java-exception | i2p GPL+Java Exception |  | 1 |
+| mif-exception | Macros and Inline Functions Exception |  | 1 |
+| openvpn-openssl-exception | OpenVPN OpenSSL Exception |  | 1 |
+| u-boot-exception-2.0 | U-Boot exception 2.0 |  | 1 |
+## Deprecated Licenses
+| ID | Name | Family | Templates | OSI Approved | FSF Libre |
+| :--- | :--- | :--- | ---: | :---: | :---: |
+| AGPL-1.0 | Affero General Public License v1.0 |  | 1 |   | Y |
+| AGPL-3.0 | GNU Affero General Public License v3.0 |  | 1 | Y | Y |
+| BSD-2-Clause-FreeBSD | BSD 2-Clause FreeBSD License |  | 1 |   | Y |
+| BSD-2-Clause-NetBSD | BSD 2-Clause NetBSD License |  | 1 |   | Y |
+| GFDL-1.1 | GNU Free Documentation License v1.1 |  | 1 |   | Y |
+| GFDL-1.2 | GNU Free Documentation License v1.2 |  | 1 |   | Y |
+| GFDL-1.3 | GNU Free Documentation License v1.3 |  | 1 |   | Y |
+| GPL-1.0 | GNU General Public License v1.0 only |  | 1 |   |   |
+| GPL-1.0+ | GNU General Public License v1.0 or later |  | 1 |   |   |
+| GPL-2.0 | GNU General Public License v2.0 only |  | 1 | Y | Y |
+| GPL-2.0+ | GNU General Public License v2.0 or later |  | 1 | Y | Y |
+| GPL-2.0-with-GCC-exception | GNU General Public License v2.0 w/GCC Runtime Library exception |  | 1 |   |   |
+| GPL-2.0-with-autoconf-exception | GNU General Public License v2.0 w/Autoconf exception |  | 1 |   |   |
+| GPL-2.0-with-bison-exception | GNU General Public License v2.0 w/Bison exception |  | 1 |   |   |
+| GPL-2.0-with-classpath-exception | GNU General Public License v2.0 w/Classpath exception |  | 1 |   |   |
+| GPL-2.0-with-font-exception | GNU General Public License v2.0 w/Font exception |  | 1 |   |   |
+| GPL-3.0 | GNU General Public License v3.0 only |  | 1 | Y | Y |
+| GPL-3.0+ | GNU General Public License v3.0 or later |  | 1 | Y | Y |
+| GPL-3.0-with-GCC-exception | GNU General Public License v3.0 w/GCC Runtime Library exception |  | 1 | Y |   |
+| GPL-3.0-with-autoconf-exception | GNU General Public License v3.0 w/Autoconf exception |  | 1 |   |   |
+| LGPL-2.0 | GNU Library General Public License v2 only |  | 1 | Y |   |
+| LGPL-2.0+ | GNU Library General Public License v2 or later |  | 1 | Y |   |
+| LGPL-2.1 | GNU Lesser General Public License v2.1 only |  | 1 | Y | Y |
+| LGPL-2.1+ | GNU Library General Public License v2.1 or later |  | 1 | Y | Y |
+| LGPL-3.0 | GNU Lesser General Public License v3.0 only |  | 1 | Y | Y |
+| LGPL-3.0+ | GNU Lesser General Public License v3.0 or later |  | 1 | Y | Y |
+| Nunit | Nunit License |  | 1 |   | Y |
+| StandardML-NJ | Standard ML of New Jersey License |  | 1 |   | Y |
+| bzip2-1.0.5 | bzip2 and libbzip2 License v1.0.5 |  | 1 |   |   |
+| eCos-2.0 | eCos license version 2.0 |  | 1 |   | Y |
+| wxWindows | wxWindows Library License |  | 1 | Y |   |
+## Deprecated Exceptions
+| ID | Name | Family | Templates |
+| :--- | :--- | :--- | ---: |
+## Runtime Configuration
+* resources: /Users/markstur/go/src/github.com/ibm/license-scanner/resources
+  * spdx/default
+  * custom/default

--- a/resources/LIST.md
+++ b/resources/LIST.md
@@ -510,6 +510,8 @@
 | ID | Name | Family | Templates |
 | :--- | :--- | :--- | ---: |
 ## Runtime Configuration
-* resources: /Users/markstur/go/src/github.com/ibm/license-scanner/resources
-  * spdx/default
+* resources: /Users/example/go/src/github.com/ibm/license-scanner/resources
+  * spdx/default  (SPDX license list 3.18)
   * custom/default
+
+###### Generated on 2022-10-05T21:48:44-07:00


### PR DESCRIPTION
The dynamic --list command should be the real source of truth (config dependent), but somewhere in the README (docs) we should show all the licenses we are providing out-of-the-box at least as an example (ideally current default or close to it).

I put --list output under resources/LIST.md (assuming we will add a resources/README.md in the future).

The main README.md just refers to this w/ a one-liner and link.  Probably too subtle, but entire listing takes up a lot of space.

Signed-off-by: Mark Sturdevant <mark.sturdevant@ibm.com>