### PR TITLE
Fix panic out of range when index map gets out of sync with normalization text

### DIFF
--- a/normalizer/normalizer_test.go
+++ b/normalizer/normalizer_test.go
@@ -5,14 +5,11 @@
 package normalizer
 
 import (
-	"encoding/hex"
 	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
-
-var FE, _ = hex.DecodeString("fe")
 
 func TestNormalizationData_NormalizeText(t *testing.T) {
 	t.Parallel()

--- a/normalizer/normalizer_test.go
+++ b/normalizer/normalizer_test.go
@@ -5,11 +5,14 @@
 package normalizer
 
 import (
+	"encoding/hex"
 	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
+
+var FE, _ = hex.DecodeString("fe")
 
 func TestNormalizationData_NormalizeText(t *testing.T) {
 	t.Parallel()
@@ -84,6 +87,24 @@ func TestNormalizationData_NormalizeText(t *testing.T) {
 				NormalizedText: "runes in commissariat à l'énergie atomique then htmltag <<omitable>>x♢z<</omitable>> .",
 			},
 		},
+		{
+			name: "Character that changes length should not cause out-of-bounds with indexMap",
+			n: &NormalizationData{
+				OriginalText: "\n\xfe\nx\n",
+			},
+			e: &NormalizationData{
+				NormalizedText: "x",
+			},
+		},
+		{
+			name: "Character that changes length should not cause out-of-bounds with indexMap (char 0)",
+			n: &NormalizationData{
+				OriginalText: "\xfe\nx\n",
+			},
+			e: &NormalizationData{
+				NormalizedText: "x",
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -109,7 +130,7 @@ func TestNormalizationData_NormalizeText_removeNoteTag(t *testing.T) {
 			OriginalText: "Something to note about <<note: Please be careful with this license>>",
 		},
 		e: &NormalizationData{
-			NormalizedText: "Something to note about  ",
+			NormalizedText: "something to note about  ",
 		},
 	}}
 
@@ -186,7 +207,7 @@ func TestNormalizationData_NormalizeText_CaptureReplaceableTextSections(t *testi
 		e: &NormalizationData{
 			CaptureGroups: []*CaptureGroup{{
 				GroupNumber: 1,
-				Name:        "replaceableSection",
+				Name:        "replaceablesection",
 				Original:    "some text",
 				Matches:     ".+?",
 			}},
@@ -622,7 +643,7 @@ func TestNormalizationData_NormalizeText_removeOddCharacters(t *testing.T) {
 			OriginalText: fmt.Sprintf("Trademark \u0099  Not sign ¬"),
 		},
 		e: &NormalizationData{
-			NormalizedText: fmt.Sprintf("Trademark    Not sign  "),
+			NormalizedText: fmt.Sprintf("trademark    not sign  "),
 		},
 	}}
 
@@ -646,7 +667,7 @@ func TestNormalizationData_NormalizeText_replaceWhitespace(t *testing.T) {
 			OriginalText: fmt.Sprintf("\nThis text   has \tsome \nwhitespace.\n"),
 		},
 		e: &NormalizationData{
-			NormalizedText: fmt.Sprintf("This text has some whitespace."),
+			NormalizedText: fmt.Sprintf("this text has some whitespace."),
 		},
 	}}
 
@@ -672,7 +693,7 @@ func TestNormalizationData_NormalizeText_Replacement_Words(t *testing.T) {
 				OriginalText: "This licence license organisation organisation to redistributions redistribution",
 			},
 			e: &NormalizationData{
-				NormalizedText: "This license license organization organization to redistribution redistribution",
+				NormalizedText: "this license license organization organization to redistribution redistribution",
 			},
 		},
 		{
@@ -680,7 +701,7 @@ func TestNormalizationData_NormalizeText_Replacement_Words(t *testing.T) {
 				OriginalText: "This license organisation to redistribution",
 			},
 			e: &NormalizationData{
-				NormalizedText: "This license organization to redistribution",
+				NormalizedText: "this license organization to redistribution",
 			},
 		},
 		{
@@ -688,7 +709,7 @@ func TestNormalizationData_NormalizeText_Replacement_Words(t *testing.T) {
 				OriginalText: "This licence organization to redistributions ",
 			},
 			e: &NormalizationData{
-				NormalizedText: "This license organization to redistribution ",
+				NormalizedText: "this license organization to redistribution ",
 			},
 		},
 	}


### PR DESCRIPTION
Create IndexMap after ToLower(). Ensure this and initialize() are only done once. Protect from out of range.

Index out of range errors can happen when the Normalized Text gets longer than the IndexMap. This was happening when ToLower() was increasing the size of NormalizedText after the IndexMap creation. Initialize was also resetting NormalizedText when called after normalization shrunk the text to "".

* ToLower() is now part of initialize()
* initialize is now only called once, as needed, protected by sync.
* The out of range exposures are also now protected.
* ToLower() is now before some matchers that were using unnecessary case-insensitive matching. Those are now optimized to assume lower.

Fixes #26

Signed-off-by: Mark Sturdevant <mark.sturdevant@ibm.com>